### PR TITLE
feat: added option to set default event context from a child component

### DIFF
--- a/doc/mixpanel_setup.md
+++ b/doc/mixpanel_setup.md
@@ -27,7 +27,7 @@ const App = () => {
 import { MixpanelEvent } from '@freshheads/analytics-essentials';
 import { executePostRequest } from '@/api/client';
 
-export const sendTrackEvent = async (data: MixpanelEvent) => {
+export const sendTrackEvent = async (data: MixpanelEvent | MixpanelPageViewEvent) => {
     return executePostRequest('_mixpanel/track', data);
 };
 ```
@@ -90,6 +90,19 @@ const App = () => {
 };
 ```
 
+Or by using setEventContext which is exposed by the useMixpanelContext hook. This would make sense if some data is not available in your root component.
+
+```tsx
+const { setEventContext } = useMixpanelContext();
+
+useEffect(() => {
+    setEventContext({
+        audience: 'Consumer',
+    });
+}, []);
+```
+
+
 ### Page view events
 
 For page view events, you can use the `trackPageView` function.
@@ -123,7 +136,7 @@ Then add this component to your app:
 
 const App = () => {
     return (
-        <MixpanelProvider eventApiClient={sendTrackEvent} defaultEventContext={defaultMixpanelEventContext}>
+        <MixpanelProvider eventApiClient={sendTrackEvent}>
             <TrackPageView />
             {children}
         </MixpanelProvider>

--- a/doc/mixpanel_setup.md
+++ b/doc/mixpanel_setup.md
@@ -151,12 +151,18 @@ They will be remembered for the duration of the session. Even if the user naviga
 
 ## Mixpanel users
 
-TODO how to handle reset mixpanel user
+Mixpanel events can be attached to a user. This is done in the backend on user login, see [FHMixpanelBundle](https://github.com/freshheads/FHMixpanelBundle) for more information.
+When using JWT tokens for authentication the token can become invalid at any time. This means that the user can become anonymous at any time.
+When the user becomes anonymous, the frontend should also reset the user in mixpanel.
+
+FHMixpanelBundle has an endpoint to do this reset user action. This library doesn't provide an implementation for it but could look like this:
+
+```tsx
+function resetMixpanelUser() {
+    executeDeleteRequest('_mixpanel/transaction');
+}
+```
 
 ## Event naming conventions
 
 TODO - how to name events
-
-## Event types
-
-TODO - how to override the event types

--- a/doc/mixpanel_setup.md
+++ b/doc/mixpanel_setup.md
@@ -166,4 +166,16 @@ function resetMixpanelUser() {
 
 ## Event naming conventions
 
-TODO - how to name events
+Our advice is to use the following naming conventions for events:
+
+1. Using present tense for events that are triggered by the user, and past tense for events that are triggered by the backend.
+> e.g. 'Add to cart' instead of 'Added to cart'
+
+2. Not using snake_case but use normal spaces for event names so it's easier to read in the mixpanel dashboard.
+> e.g. 'Add to cart' instead of 'add_to_cart'
+
+3. Grouping events by using context properties instead of adding them to the event name.
+> e.g. 'Click button' with context { section: 'hero' } instead of 'Click hero button'
+
+4. Using short and descriptive names.
+

--- a/doc/mixpanel_setup.md
+++ b/doc/mixpanel_setup.md
@@ -129,6 +129,7 @@ export default function TrackPageView() {
     return null;
 }
 ```
+> Tip: use pathname as a dependency for the useEffect hook. This way it will not trigger on query param changes. If you want to track query changes, you could use location.href as a dependency.
 
 Then add this component to your app:
 

--- a/lib/mixpanel/context.tsx
+++ b/lib/mixpanel/context.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useContext, useEffect } from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react';
 import { MixpanelEvent, MixpanelPageViewEvent } from './types';
 import {
     extractUtmParams,
@@ -11,6 +11,7 @@ import {
 interface MixpanelContextProps {
     trackEvent: (event: MixpanelEvent) => void;
     trackPageView: (event: MixpanelPageViewEvent) => void;
+    setEventContext: (context: MixpanelEvent['context']) => void;
 }
 
 interface MixpanelProviderProps {
@@ -38,6 +39,10 @@ export function MixpanelProvider({
     eventApiClient,
     defaultEventContext,
 }: MixpanelProviderProps) {
+    const [eventContext, setEventContext] = useState<MixpanelEvent['context']>(
+        defaultEventContext || {}
+    );
+
     const trackEvent = (event: MixpanelEvent) => {
         // only send events on the client
         if (typeof window === 'undefined') {
@@ -52,7 +57,7 @@ export function MixpanelProvider({
                 title: document.title,
                 pathname: window.location.pathname,
                 pwa: isStandalonePWA(),
-                ...defaultEventContext,
+                ...eventContext,
                 ...utmParams,
                 ...event.context,
             },
@@ -87,6 +92,7 @@ export function MixpanelProvider({
             value={{
                 trackEvent,
                 trackPageView,
+                setEventContext,
             }}
         >
             {children}

--- a/test/mixpanel.test.tsx
+++ b/test/mixpanel.test.tsx
@@ -76,8 +76,19 @@ describe('MixpanelContext', () => {
         });
     };
 
-    function TrackEventTestingComponent() {
-        const { trackEvent } = useMixpanelContext();
+    function TrackEventTestingComponent({
+        defaultEventContext,
+    }: {
+        defaultEventContext?: MixpanelEvent['context'];
+    }) {
+        const { trackEvent, setEventContext } = useMixpanelContext();
+
+        useEffect(() => {
+            if (defaultEventContext) {
+                setEventContext(defaultEventContext);
+            }
+        }, [defaultEventContext]);
+
         return (
             <button
                 onClick={() =>
@@ -141,7 +152,7 @@ describe('MixpanelContext', () => {
         });
     });
 
-    test('provider can extend the default context for event tracking', () => {
+    test('provider can extend the default context for event tracking with provider prop', () => {
         const defaultEventContext = {
             href: 'https://example.com',
             pathname: '/example',
@@ -153,6 +164,36 @@ describe('MixpanelContext', () => {
             {
                 contextWrapperProps: { defaultEventContext },
             }
+        );
+
+        fireEvent.click(getByText('button'));
+
+        expect(eventApiClient).toHaveBeenCalledWith({
+            name: 'event name',
+            context: {
+                title: 'Page title',
+                href: 'https://example.com',
+                pathname: '/example',
+                pwa: false,
+                audience: 'Consumer',
+            },
+            data: {
+                productId: '123',
+            },
+        });
+    });
+
+    test('Default event context can be extended from a child component', () => {
+        const defaultEventContext = {
+            href: 'https://example.com',
+            pathname: '/example',
+            audience: 'Consumer',
+        };
+
+        const { getByText } = renderWithMixpanelProvider(
+            <TrackEventTestingComponent
+                defaultEventContext={defaultEventContext}
+            />
         );
 
         fireEvent.click(getByText('button'));


### PR DESCRIPTION
@rensio in deze pr zitten ook wat aanpassingen voor de docs. Je kan het ook later in totaal beoordelen bij het issue over docs.